### PR TITLE
fix: persist ACP session id in chat history

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -78,7 +78,6 @@ Sidebar.__index = Sidebar
 ---@field old_result_lines avante.ui.Line[]
 ---@field token_count integer | nil
 ---@field acp_client avante.acp.ACPClient | nil
----@field acp_session_id string | nil
 ---@field post_render? fun(sidebar: avante.Sidebar)
 ---@field permission_handler fun(id: string) | nil
 ---@field permission_button_options ({ id: string, icon: string|nil, name: string }[]) | nil
@@ -2220,7 +2219,6 @@ function Sidebar:new_chat(args, cb)
   Path.history.save(self.code.bufnr, history)
   self:reload_chat_history()
   self.current_state = nil
-  self.acp_session_id = nil
   self.expanded_message_uuids = {}
   self.tool_message_positions = {}
   self.current_tool_use_extmark_id = nil
@@ -2825,8 +2823,11 @@ function Sidebar:create_input_container()
         on_state_change = on_state_change,
         acp_client = self.acp_client,
         on_save_acp_client = function(client) self.acp_client = client end,
-        acp_session_id = self.acp_session_id,
-        on_save_acp_session_id = function(session_id) self.acp_session_id = session_id end,
+        acp_session_id = self.chat_history.acp_session_id,
+        on_save_acp_session_id = function(session_id)
+          self.chat_history.acp_session_id = session_id
+          Path.history.save(self.code.bufnr, self.chat_history)
+        end,
         set_tool_use_store = set_tool_use_store,
         get_history_messages = function(opts) return self:get_history_messages_for_api(opts) end,
         get_todos = function()

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -510,6 +510,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field filename string
 ---@field system_prompt string | nil
 ---@field tokens_usage avante.LLMTokenUsage | nil
+---@field acp_session_id string | nil
 ---
 ---@class avante.ChatMemory
 ---@field content string


### PR DESCRIPTION
### Summary

Persist the ACP session id across chats and restarts by storing it in `chat_history` and saving on update. This prevents losing the active ACP session when starting a new chat or reopening Neovim.

### Changes
- Move `acp_session_id` from sidebar state to `chat_history`
- Save `chat_history` when `acp_session_id` changes
- Add `acp_session_id` to `avante.ChatHistory` in `types.lua`

### Rationale
`acp_session_id` should be tied to the chat history rather than the ephemeral sidebar instance to ensure continuity.

### Testing
- Manually verified that starting a new chat or restarting Neovim retains the ACP session id.

### Notes
No functional changes outside of session persistence; UI unaffected.