### PR TITLE
fix: resolve CI typecheck and unit test failures

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -266,9 +266,7 @@ function M.generate_prompts(opts)
     local lines = Utils.read_file_from_buf_or_disk(instruction_file_path:absolute())
     local instruction_content = lines and table.concat(lines, "\n") or ""
 
-    if instruction_content then 
-      opts.instructions = (opts.instructions or "") .. "\n" .. instruction_content 
-    end
+    if instruction_content then opts.instructions = (opts.instructions or "") .. "\n" .. instruction_content end
     opts._instructions_loaded = true
   end
 
@@ -441,9 +439,8 @@ function M.generate_prompts(opts)
     :filter(function(msg) return type(msg.content) ~= "string" or msg.content ~= "" end)
     :totable()
 
-  if opts.instructions ~= nil and opts.instructions ~= "" and not opts._instructions_added_to_messages then
+  if opts.instructions ~= nil and opts.instructions ~= "" then
     messages = vim.list_extend(messages, { { role = "user", content = opts.instructions } })
-    opts._instructions_added_to_messages = true
   end
 
   opts.session_ctx = opts.session_ctx or {}

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -418,6 +418,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field update_snippets? string[]
 ---@field prompt_opts? AvantePromptOptions
 ---@field session_ctx? table
+---@field _instructions_loaded? boolean
 ---
 ---@class AvanteLLMToolHistory
 ---@field tool_result? AvanteLLMToolResult

--- a/tests/llm_spec.lua
+++ b/tests/llm_spec.lua
@@ -156,11 +156,11 @@ describe("generate_prompts", function()
     local opts = {}
     llm.generate_prompts(opts)
     local first_instructions = opts.instructions
-    
+
     -- Call again with the same opts object
     llm.generate_prompts(opts)
     local second_instructions = opts.instructions
-    
+
     -- Instructions should be the same, not duplicated
     assert.are.same(first_instructions, second_instructions)
     -- Verify that mock content is present (more flexible than hardcoded exact match)
@@ -169,27 +169,35 @@ describe("generate_prompts", function()
 
   it("should not duplicate instructions in messages when called multiple times with same opts", function()
     local opts = {
-      instructions = "Test instructions"
+      instructions = "Test instructions",
     }
-    
+
     -- First call
     local result1 = llm.generate_prompts(opts)
     local instruction_message_count1 = 0
-    for _, msg in ipairs(result1.session_ctx.messages) do
-      if msg.role == "user" and msg.content == "Test instructions" then
+    for _, msg in ipairs(result1.messages) do
+      if
+        msg.role == "user"
+        and type(msg.content) == "string"
+        and string.find(msg.content, "Test instructions", 1, true)
+      then
         instruction_message_count1 = instruction_message_count1 + 1
       end
     end
-    
+
     -- Second call with same opts
     local result2 = llm.generate_prompts(opts)
     local instruction_message_count2 = 0
-    for _, msg in ipairs(result2.session_ctx.messages) do
-      if msg.role == "user" and msg.content == "Test instructions" then
+    for _, msg in ipairs(result2.messages) do
+      if
+        msg.role == "user"
+        and type(msg.content) == "string"
+        and string.find(msg.content, "Test instructions", 1, true)
+      then
         instruction_message_count2 = instruction_message_count2 + 1
       end
     end
-    
+
     -- Should have instructions message only once in both calls
     assert.are.same(1, instruction_message_count1)
     assert.are.same(1, instruction_message_count2)


### PR DESCRIPTION
## Summary
- Add missing `_instructions_loaded` field to `AvanteGeneratePromptsOptions` type definition to fix lua-language-server `inject-field` warning
- Remove buggy `_instructions_added_to_messages` flag that incorrectly prevented instructions from being included in messages on subsequent `generate_prompts` calls (messages are rebuilt from scratch each call, so the flag caused instructions to be dropped)
- Fix test to access `result.messages` instead of `result.session_ctx.messages` (the return value has `messages` directly, not under `session_ctx`)
- Fix test string matching to use `string.find` for substring matching since instructions content may be concatenated with avante.md file content

## Test plan
- [x] `make luatest` passes for all `llm_spec.lua` tests (8/8 pass)
- [x] Pre-commit hooks (StyLua, Luacheck) pass
- [ ] CI typecheck job should pass (inject-field warnings resolved)
- [ ] CI unit test job should pass (session_ctx nil access and instruction dedup test fixed)