### PR TITLE
fix: add missing `local` to platform variable in utils

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -43,7 +43,7 @@ M.path_sep = M.path.SEP
 
 ---@return "linux" | "darwin" | "windows"
 function M.get_os_name()
-  platform = require("avante.utils.platform").platform
+  local platform = require("avante.utils.platform").platform
   if platform == "linux" or platform == "wsl" or platform == "msys2" then
     return "linux"
   elseif platform == "macos" then


### PR DESCRIPTION
## Problem

`lua/avante/utils/init.lua:46` assigns to `platform` without `local`, triggering lua-language-server's `lowercase-global` diagnostic. This fails the Typecheck CI on both `main` and `feature/rag_optimizations`.

## Fix

```diff
- platform = require("avante.utils.platform").platform
+ local platform = require("avante.utils.platform").platform
```