### PR TITLE
fix(build): make make build work with build directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@ TARGET_LIBRARY ?= all
 RAG_SERVICE_VERSION ?= 0.0.11
 RAG_SERVICE_IMAGE := quay.io/yetoneful/avante-rag-service:$(RAG_SERVICE_VERSION)
 
+.PHONY: all build
 all: luajit
+
+build: all
 
 define make_definitions
 ifeq ($(BUILD_FROM_SOURCE),true)

--- a/build.sh
+++ b/build.sh
@@ -25,16 +25,19 @@ Linux*)
   PLATFORM="linux"
   CARGO_EXT="so"
   LIB_EXT="so"
+  ARCHIVE_EXT="tar.gz"
   ;;
 Darwin*)
   PLATFORM="darwin"
   CARGO_EXT="dylib"
   LIB_EXT="so"
+  ARCHIVE_EXT="tar.gz"
   ;;
 CYGWIN* | MINGW* | MSYS*)
   PLATFORM="windows"
   CARGO_EXT="dll"
   LIB_EXT="dll"
+  ARCHIVE_EXT="zip"
   ;;
 *)
   echo "Unsupported platform"
@@ -97,6 +100,60 @@ save_tag() {
   echo "$latest_tag" > "${TARGET_DIR}/.tag"
 }
 
+build_from_source() {
+  echo "Building from source."
+  cargo build --release --features="$LUA_VERSION"
+  for f in target/release/lib*."$CARGO_EXT"; do
+    filename=$(basename "$f" | sed 's/^lib//' | sed "s/\.$CARGO_EXT$/.$LIB_EXT/")
+    cp "$f" "${TARGET_DIR}/${filename}"
+  done
+}
+
+download_and_extract() {
+  local url="$1"
+  local tmpfile
+  tmpfile=$(mktemp -t avante_lib.XXXXXX)
+
+  if ! curl -fL "$url" -o "$tmpfile"; then
+    rm -f "$tmpfile"
+    return 1
+  fi
+
+  if [[ "$url" == *.zip ]]; then
+    unzip -o "$tmpfile" -d "$TARGET_DIR"
+  else
+    tar -zxv -f "$tmpfile" -C "$TARGET_DIR"
+  fi
+  local status=$?
+  rm -f "$tmpfile"
+  return $status
+}
+
+download_with_gh() {
+  local tmpdir
+  tmpdir=$(mktemp -d -t avante_lib.XXXXXX)
+
+  if ! gh release download "$latest_tag" --repo "github.com/$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --clobber --dir "$tmpdir"; then
+    rm -rf "$tmpdir"
+    return 1
+  fi
+
+  local artifacts=("$tmpdir"/*)
+  if [[ ${#artifacts[@]} -ne 1 || ! -f "${artifacts[0]}" ]]; then
+    rm -rf "$tmpdir"
+    return 1
+  fi
+
+  if [[ "${artifacts[0]}" == *.zip ]]; then
+    unzip -o "${artifacts[0]}" -d "$TARGET_DIR"
+  else
+    tar -zxv -f "${artifacts[0]}" -C "$TARGET_DIR"
+  fi
+  local status=$?
+  rm -rf "$tmpdir"
+  return $status
+}
+
 if [[ "$latest_tag" = "$built_tag" && -n "$latest_tag" ]]; then
   echo "Local build is up to date $latest_tag. No download needed."
 elif [[ "$latest_tag" != "$built_tag" && -n "$latest_tag" ]]; then
@@ -104,22 +161,28 @@ elif [[ "$latest_tag" != "$built_tag" && -n "$latest_tag" ]]; then
 
   set -x
   if test_command "gh" && test_gh_auth; then
-    gh release download "$latest_tag" --repo "github.com/$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --clobber --output - | tar -zxv -C "$TARGET_DIR"
-    save_tag
+    if download_with_gh; then
+      save_tag
+    else
+      build_from_source
+    fi
   else
     # Get the artifact download URL
-    ARTIFACT_URL=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$latest_tag" | grep "browser_download_url" | cut -d '"' -f 4 | grep "$ARTIFACT_NAME_PATTERN")
+    ARTIFACT_URL=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$latest_tag" | grep "browser_download_url" | cut -d '"' -f 4 | grep "$ARTIFACT_NAME_PATTERN" || true)
 
     mkdir -p "$TARGET_DIR"
 
-    curl -L "$ARTIFACT_URL" | tar -zxv -C "$TARGET_DIR"
-    save_tag
+    if [[ -z "$ARTIFACT_URL" ]]; then
+      ARTIFACT_URL="https://github.com/$REPO_OWNER/$REPO_NAME/releases/download/$latest_tag/$ARTIFACT_NAME_PATTERN.$ARCHIVE_EXT"
+    fi
+
+    if download_and_extract "$ARTIFACT_URL"; then
+      save_tag
+    else
+      build_from_source
+    fi
   fi
 else
   echo "No latest tag found. Building from source."
-  cargo build --release --features="$LUA_VERSION"
-  for f in target/release/lib*."$CARGO_EXT"; do
-    filename=$(basename "$f" | sed 's/^lib//' | sed "s/\.$CARGO_EXT$/.$LIB_EXT/")
-    cp "$f" "${TARGET_DIR}/${filename}"
-  done
+  build_from_source
 fi


### PR DESCRIPTION
- 将 build 声明为 phony 目标，避免被 build 目录遮蔽
- 增强 release 产物下载失败时的回退逻辑
- 按平台处理 tar.gz 和 zip 构建产物

en
```
## Summary

    This fixes `make build` when the repository contains an existing `build/` directory.

    ## Changes

    - Mark `build` as a phony Make target and map it to the default build flow.
    - Make release artifact download more robust when GitHub API lookup fails.
    - Handle `tar.gz` and `zip` release archives according to platform.
    - Fall back to source build when artifact download fails.

    ## Test

    - `bash -n build.sh`
    - `make build`
```