### PR TITLE
ci: build libraries as user would on windows as well

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -51,12 +51,22 @@ runs:
           ls -lRa lua
 
 
+      - uses: rhysd/action-setup-vim@v1
+        if: ${{ inputs.os_name == 'windows' }}
+        with:
+          neovim: true
+          version: v0.11.0
+
       - name: Build all crates (Windows)
         if: ${{ inputs.os_name == 'windows' }}
         shell: bash
         run: |
           # TODO run AvanteBuild instead
-          cargo build --release --features ${{ matrix.feature }} --target ${{ inputs.rust_target }}
+          nvim -V3nvim.log --headless -u NONE --cmd "set rtp^=."  -c "runtime plugin/avante.lua" -c  "lua vim.g.avante = { debug= vim.log.levels.INFO }" -c "AvanteBuild source=true" +quit!
+
+          # to help diagnose failures
+          cat nvim.log
+          ls -lRa lua
 
       - name: Build all crates (Linux) with glibc 2.17 # for glibc 2.17
         shell: bash

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -51,12 +51,22 @@ runs:
         ls -la lua
 
 
+    - uses: rhysd/action-setup-vim@v1
+      if: ${{ inputs.os_name == 'windows' }}
+      with:
+        neovim: true
+        version: v0.12.0
+
     - name: Build all crates (Windows)
       if: ${{ inputs.os_name == 'windows' }}
       shell: bash
       run: |
         # TODO run AvanteBuild instead
-        cargo build --release --features ${{ matrix.feature }} --target ${{ inputs.rust_target }}
+        nvim -V3nvim.log --headless -u NONE --cmd "set rtp^=."  -c "runtime plugin/avante.lua" -c  "lua vim.g.avante = { debug= vim.log.levels.INFO }" -c "AvanteBuild source=true" +quit!
+
+        # to help diagnose failures
+        cat nvim.log
+        ls -lRa lua
 
     - name: Build all crates (Linux) with glibc 2.17 # for glibc 2.17
       shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,6 +47,7 @@ jobs:
           os:
             - ubuntu-24.04
             - macos-latest # fails because of missing docker
+            - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -54,9 +55,14 @@ jobs:
 
       - uses: ./.github/actions/build
         with:
-          os: ubuntu-latest
-          os_name: linux
-          arch: x86_64
+            os: windows-latest
+            os_name: windows
+            arch: x86_64
+            rust_target: x86_64-pc-windows-msvc
+
+          # os: ubuntu-latest
+          # os_name: linux
+          # arch: x86_64
           # rust_target: x86_64-unknown-linux-gnu
           # docker_platform: linux/amd64
           # container: quay.io/pypa/manylinux2014_x86_64 # for glibc 2.17


### PR DESCRIPTION
I previously reworked the CI to move the "build" part of the release into its own action. The goal is to test the build in PRs (just for linux by default, easy enough to enable tests for windows on a specifc PR).
The goal is to build the release with the same command a user would do it, ie., through AvanteBuild. Seems to work for darwin/linux.

I am trying to do this on windows but this seems a bit different.