### PR TITLE
fix: don't set reasoning_content to empty string on assistant messages

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -323,7 +323,7 @@ function M:parse_messages(opts)
                   content = "",
                 }
 
-                tool_call_message.reasoning_content = pending_reasoning_content or ""
+                tool_call_message.reasoning_content = pending_reasoning_content
                 pending_reasoning_content = nil
 
                 table.insert(messages, tool_call_message)


### PR DESCRIPTION
Fixes #3186

Strict-schema OpenAI-compatible servers (e.g. some Mistral deployments) reject unknown fields entirely, including reasoning_content when it's an empty string. Only set the field when there's actual content.