### PR TITLE
feat: add OrcaRouter as a built-in provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,37 @@ You may need to run `AvanteSwitchProvider claude` to initiate the authentication
 
 ```
 
+### Using OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an AI gateway that exposes 180+ models
+(OpenAI, Anthropic, Google, DeepSeek, and more) behind a single OpenAI-compatible
+endpoint. It also runs gateway-level, zero-trust security for AI agents on the
+same endpoint — screening every prompt/response and governing every tool call on a
+default-deny basis, with no application code changes.
+
+Select the built-in `orcarouter` provider and export your API key:
+
+```lua
+  provider = "orcarouter", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
+```
+
+```sh
+export ORCAROUTER_API_KEY=your-api-key
+# or scoped: export AVANTE_ORCAROUTER_API_KEY=your-api-key
+```
+
+The default model is `orcarouter/auto`, which routes each request to the best
+model for the task. You can pick any model from the catalog
+(https://www.orcarouter.ai/models) instead:
+
+```lua
+  providers = {
+    orcarouter = {
+      model = "openai/gpt-5.5",
+    },
+  },
+```
+
 ### Basic Functionality
 
 Given its early stage, `avante.nvim` currently supports the following basic functionalities:
@@ -958,6 +989,7 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > export AVANTE_CO_API_KEY=your-cohere-api-key
 > export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
 > export AVANTE_MOONSHOT_API_KEY=your-moonshot-api-key
+> export AVANTE_ORCAROUTER_API_KEY=your-orcarouter-api-key
 > ```
 >
 > **Global API Keys (Legacy)**

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -833,6 +833,12 @@ M._defaults = {
         max_tokens = 4096, -- to avoid using the unsupported max_completion_tokens
       },
     },
+    orcarouter = {
+      __inherited_from = "openai",
+      endpoint = "https://api.orcarouter.ai/v1",
+      model = "orcarouter/auto",
+      api_key_name = "ORCAROUTER_API_KEY",
+    },
   },
   ---Specify the special dual_boost mode
   ---1. enabled: Whether to enable dual_boost mode. Default to false.


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a built-in `orcarouter` provider in `lua/avante/config.lua`, mirroring the existing `aihubmix` / `moonshot` / `xai` / `mistral` entries. It inherits the OpenAI-compatible transport, points at `https://api.orcarouter.ai/v1`, and reads `ORCAROUTER_API_KEY` (or the scoped `AVANTE_ORCAROUTER_API_KEY`).

OrcaRouter is an OpenAI-compatible model routing gateway that exposes 180+ models (OpenAI, Anthropic, Google, DeepSeek and more) behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Motivation

Avante already ships first-class providers for several OpenAI-compatible aggregators (aihubmix, moonshot, xai, glm, qwen, mistral). Adding OrcaRouter as a named provider makes it selectable via `provider = "orcarouter"` with the same UX, instead of requiring users to hand-write a custom provider block.

## Changes

- `lua/avante/config.lua`: register the `orcarouter` provider (`__inherited_from = "openai"`, endpoint `https://api.orcarouter.ai/v1`, `api_key_name = "ORCAROUTER_API_KEY"`, default model `orcarouter/auto`).
- `README.md`: document the provider under "Using OrcaRouter" and add `AVANTE_ORCAROUTER_API_KEY` to the scoped API keys list.

## Backward compatibility

Fully backward compatible — the new entry is purely additive. Users who don't set `ORCAROUTER_API_KEY` are unaffected; users who do can switch with `AvanteSwitchProvider orcarouter` (or `provider = "orcarouter"` in their setup).

## Testing

- `stylua --check lua/avante/config.lua` passes.
- Live API: `GET https://api.orcarouter.ai/v1/models` returns 200 (193 models, including `orcarouter/auto`); a chat completion with the provider's request shape (`temperature`, `max_completion_tokens`, `reasoning_effort`, `tools`) returns 200, and an explicit tool-call request resolves to a real `record_fact` call.
