### PR TITLE
fix(gemini): bump the default model

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -666,7 +666,7 @@ M._defaults = {
     ---@type AvanteSupportedProvider
     gemini = {
       endpoint = "https://generativelanguage.googleapis.com/v1beta/models",
-      model = "gemini-2.0-flash",
+      model = "gemini-3.6-flash",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
       use_ReAct_prompt = true,


### PR DESCRIPTION
ideally we would not need to setup a model but without a model, avante fails for now (tries to set a nil model). Proper fix reserved for later.

using flash 3.7 I got a "too busy answer" so let's default to a less busy one.