### PR TITLE
feat: add OrcaRouter as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ For building binary if you wish to build from source, then `cargo` is required. 
           max_tokens = 32768,
         },
       },
+      orcarouter = {
+        endpoint = "https://api.orcarouter.ai/v1",
+        model = "openai/gpt-5.5",
+        timeout = 30000, -- Timeout in milliseconds
+        extra_request_body = {
+          temperature = 0.75,
+          max_tokens = 20480,
+        },
+      },
     },
   },
   dependencies = {
@@ -901,6 +910,7 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > export AVANTE_CO_API_KEY=your-cohere-api-key
 > export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
 > export AVANTE_MOONSHOT_API_KEY=your-moonshot-api-key
+> export AVANTE_ORCAROUTER_API_KEY=your-orcarouter-api-key
 > ```
 >
 > **Global API Keys (Legacy)**

--- a/README_zh.md
+++ b/README_zh.md
@@ -78,6 +78,15 @@
             max_tokens = 32768,
           },
       },
+      orcarouter = {
+        endpoint = "https://api.orcarouter.ai/v1",
+        model = "openai/gpt-5.5",
+        timeout = 30000, -- 超时时间（毫秒）
+        extra_request_body = {
+          temperature = 0.75,
+          max_tokens = 20480,
+        },
+      },
     },
   },
   dependencies = {
@@ -320,6 +329,15 @@ _请参见 [config.lua#L9](./lua/avante/config.lua) 以获取完整配置_
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 32768,
+      },
+    },
+    orcarouter = {
+      endpoint = "https://api.orcarouter.ai/v1",
+      model = "openai/gpt-5.5",
+      timeout = 30000, -- 超时时间（毫秒）
+      extra_request_body = {
+        temperature = 0.75,
+        max_tokens = 20480,
       },
     },
   },
@@ -619,6 +637,7 @@ Avante.nvim 提供了多个可以与 blink.cmp 集成的补全项：
 > export AVANTE_CO_API_KEY=your-cohere-api-key
 > export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
 > export AVANTE_MOONSHOT_API_KEY=your-moonshot-api-key
+> export AVANTE_ORCAROUTER_API_KEY=your-orcarouter-api-key
 > ```
 >
 > **全局 API 密钥（传统方式）**

--- a/doc/avante.txt
+++ b/doc/avante.txt
@@ -3189,6 +3189,7 @@ avante.Providers                                              *avante.Providers*
         {mistral}                 (AvanteProviderFunctor)
         {ollama}                  (AvanteProviderFunctor)
         {openai}                  (AvanteProviderFunctor)
+        {orcarouter}              (AvanteProviderFunctor)
         {vertex_claude}           (AvanteProviderFunctor)
         {watsonx_code_assistant}  (AvanteProviderFunctor)
 
@@ -3541,6 +3542,13 @@ M:transform_tool({tool})                *avante-providers-openai:transform_tool*
 
 M.is_openrouter()                        *avante-providers-openai.is_openrouter*
     Check if url belongs to openrouter
+
+    Returns: ~
+        (boolean)
+
+
+M.is_orcarouter()                       *avante-providers-openai.is_orcarouter*
+    Check if url belongs to orcarouter
 
     Returns: ~
         (boolean)

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -809,6 +809,15 @@ M._defaults = {
         max_tokens = 4096, -- to avoid using the unsupported max_completion_tokens
       },
     },
+    orcarouter = {
+      __inherited_from = "openai",
+      endpoint = "https://api.orcarouter.ai/v1",
+      model = "openai/gpt-5.5",
+      api_key_name = "ORCAROUTER_API_KEY",
+      extra_request_body = {
+        max_completion_tokens = 20480,
+      },
+    },
   },
   ---Specify the special dual_boost mode
   ---1. enabled: Whether to enable dual_boost mode. Default to false.

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -34,6 +34,7 @@ local Utils = require("avante.utils")
 ---@field mistral AvanteProviderFunctor
 ---@field ollama AvanteProviderFunctor
 ---@field openai AvanteProviderFunctor
+---@field orcarouter AvanteProviderFunctor
 ---@field vertex_claude AvanteProviderFunctor
 ---@field watsonx_code_assistant AvanteProviderFunctor
 local M = {}

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -46,6 +46,10 @@ end
 ---@return boolean
 function M.is_openrouter(url) return url:match("^https://openrouter%.ai/") end
 
+---Check if url belongs to orcarouter
+---@return boolean
+function M.is_orcarouter(url) return url:match("^https://api%.orcarouter%.ai/") end
+
 ---Check if url belongs to mistral
 ---@return boolean
 function M.is_mistral(url) return url:match("^https://api%.mistral%.ai/") end
@@ -836,6 +840,12 @@ function M:parse_curl_args(prompt_opts)
   end
 
   if M.is_openrouter(provider_conf.endpoint) then
+    headers["HTTP-Referer"] = "https://github.com/yetone/avante.nvim"
+    headers["X-Title"] = "Avante.nvim"
+    request_body.include_reasoning = true
+  end
+
+  if M.is_orcarouter(provider_conf.endpoint) then
     headers["HTTP-Referer"] = "https://github.com/yetone/avante.nvim"
     headers["X-Title"] = "Avante.nvim"
     request_body.include_reasoning = true


### PR DESCRIPTION
avante.nvim is a Neovim plugin designed to emulate the behaviour of the Cursor AI IDE, and its whole point is that you bring your own AI. Today you can already point it at OpenAI-compatible endpoints manually, but that means picking one vendor, one model, and pasting in a key per provider. If you would rather let a gateway choose the best model for each request, OrcaRouter gives you a single endpoint and a single key that routes across many upstream models.

This adds `orcarouter` as a named provider in `lua/avante/config.lua`, following the same shape as the existing `moonshot` / `xai` / `mistral` entries. It inherits from the openai provider, sets `endpoint` to `https://api.orcarouter.ai/v1`, reads `ORCAROUTER_API_KEY`, and defaults to the `openai/gpt-5.5` model. In `lua/avante/providers/openai.lua` it mirrors the existing `is_openrouter` handling: when the endpoint matches `api.orcarouter.ai`, avante sends the `HTTP-Referer` / `X-Title` attribution headers and requests reasoning content via `include_reasoning`.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes:
- `lua/avante/config.lua`: add the `orcarouter` provider entry (inherits from `openai`)
- `lua/avante/providers/openai.lua`: add `is_orcarouter()` plus the attribution / reasoning handling in `parse_curl_args`
- `lua/avante/providers/init.lua`: document the new `orcarouter` provider field
- `README.md` / `README_zh.md`: add `orcarouter` to the config example and the scoped API keys list
- `doc/avante.txt`: update the generated vimdoc for the new function and field

Verification:
- Lua syntax checked for all modified modules
- Live-tested the exact request shape this provider emits against `https://api.orcarouter.ai/v1`: non-stream chat, stream chat, tool calling, and `orcarouter/auto` routing all returned 200; an invalid key returned 401

I'm an engineer on the OrcaRouter team.
