### PR TITLE
doc: initial doc for avante-api

### DIFF
--- a/doc/avante.txt
+++ b/doc/avante.txt
@@ -26,6 +26,7 @@ Usage ·····································
  ······································································ |avante|
 Configuration via variable ······································ |vim.g.avante|
 Configuration ·················································· |avante-config|
+Avante API ························································ |avante-api|
 Commands (:AvanteAsk,...) ···································· |avante-commands|
 Sidebar ······················································· |avante-sidebar|
 Slash commands ·········································· |avante-slashcommands|
@@ -573,6 +574,128 @@ M.get_provider_config({provider_name})       *avante-config.get_provider_config*
 
 
 ==============================================================================
+Avante API                                                          *avante-api*
+
+A collection of functions to build your own avante experience.
+
+avante.ApiToggle                                              *avante.ApiToggle*
+
+    Fields: ~
+        {debug}  (ToggleBind.wrap)  @operator call(): boolean
+        {hint}   (ToggleBind.wrap)
+
+
+avante.Api                                                          *avante.Api*
+
+    Fields: ~
+        {toggle}  (avante.ApiToggle)
+
+
+                                           *avante-api.switch_selector_provider*
+M.switch_selector_provider({target_provider})
+
+    Parameters: ~
+        {target_provider}  (avante.SelectorProvider)
+
+
+M.switch_input_provider({target_provider})    *avante-api.switch_input_provider*
+
+    Parameters: ~
+        {target_provider}  (avante.InputProvider)
+
+
+M.switch_provider({target})                         *avante-api.switch_provider*
+
+    Parameters: ~
+        {target}  (avante.ProviderName)
+
+
+M.build({opts?})                                              *avante-api.build*
+    Command to install the necessary rust libraries
+    Defaults to download the libraries but passing `source=true` will force a local build via cargo
+    Blocking as it waits for cargo to finish
+
+    Parameters: ~
+        {opts?}  ({source:boolean})
+
+
+AskOptions                                                          *AskOptions*
+
+    Fields: ~
+        {question?}             (string)                       optional questions
+        {win?}                  (table<string,any>)            windows options similar to |nvim_open_win()|
+        {ask?}                  (boolean)
+        {floating?}             (boolean)                      whether to open a floating input to enter the question
+        {new_chat?}             (boolean)                      whether to open a new chat
+        {without_selection?}    (boolean)                      whether to open a new chat without selection
+        {sidebar_pre_render?}   (fun(sidebar:avante.Sidebar))
+        {sidebar_post_render?}  (fun(sidebar:avante.Sidebar))
+        {project_root?}         (string)                       optional project root
+        {show_logo?}            (boolean)                      whether to show the logo
+
+
+M.full_view_ask()                                     *avante-api.full_view_ask*
+
+
+M.ask({opts?})                                                  *avante-api.ask*
+
+    Parameters: ~
+        {opts?}  (AskOptions)
+
+
+M.edit({request?}, {line1?}, {line2?})                         *avante-api.edit*
+
+    Parameters: ~
+        {request?}  (string)
+        {line1?}    (integer)
+        {line2?}    (integer)
+
+
+M.get_suggestion()                                   *avante-api.get_suggestion*
+
+    Returns: ~
+        (avante.Suggestion|nil)
+
+
+M.refresh({opts?})                                          *avante-api.refresh*
+
+    Parameters: ~
+        {opts?}  (AskOptions)
+
+
+M.focus({opts?})                                              *avante-api.focus*
+
+    Parameters: ~
+        {opts?}  (AskOptions)
+
+
+M.select_model()                                       *avante-api.select_model*
+    Select a model
+    Saves the choice to stdpath("state")
+
+
+M.select_acp_model()                               *avante-api.select_acp_model*
+
+
+M.select_acp_mode()                                 *avante-api.select_acp_mode*
+
+
+M.select_history()                                   *avante-api.select_history*
+
+
+M.add_buffer_files()                               *avante-api.add_buffer_files*
+
+
+M.add_selected_file()                             *avante-api.add_selected_file*
+
+
+M.remove_selected_file()                       *avante-api.remove_selected_file*
+
+
+M.stop()                                                       *avante-api.stop*
+
+
+==============================================================================
 Commands (:AvanteAsk,...)                                      *avante-commands*
 
 
@@ -643,7 +766,7 @@ Commands (:AvanteAsk,...)                                      *avante-commands*
 
                                                      *:AvanteModels*
  :AvanteModels
-         Show the model list.
+         Show the model list. See |avante-api.select_model|
 
                                                      *:AvanteACPModels*
  :AvanteACPModels
@@ -918,15 +1041,6 @@ Sidebar:retry_user_request()                 *avante-sidebar:retry_user_request*
 Sidebar:handle_expand_message()           *avante-sidebar:handle_expand_message*
 
 
-Sidebar:edit_user_request()                   *avante-sidebar:edit_user_request*
-
-
-Sidebar:apply({current_cursor})                           *avante-sidebar:apply*
-
-    Parameters: ~
-        {current_cursor}  (boolean)
-
-
 Sidebar:render_header()                           *avante-sidebar:render_header*
     When include_model is set, in ACP mode, model will be rendered as "model | mode"
     else it will be set as
@@ -940,23 +1054,6 @@ Sidebar:render_input({ask?})                       *avante-sidebar:render_input*
 
     Parameters: ~
         {ask?}  (boolean)
-
-
-Sidebar:render_selected_code()             *avante-sidebar:render_selected_code*
-
-
-Sidebar:bind_apply_key()                         *avante-sidebar:bind_apply_key*
-
-
-Sidebar:unbind_apply_key()                     *avante-sidebar:unbind_apply_key*
-
-
-                                    *avante-sidebar:bind_retry_user_request_key*
-Sidebar:bind_retry_user_request_key()
-
-
-                                  *avante-sidebar:unbind_retry_user_request_key*
-Sidebar:unbind_retry_user_request_key()
 
 
 Sidebar:bind_expand_tool_use_key()     *avante-sidebar:bind_expand_tool_use_key*

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -1,3 +1,8 @@
+---@mod avante-api Avante API
+---
+---@brief [[
+---A collection of functions to build your own avante experience.
+---@brief ]]
 local Config = require("avante.config")
 local Utils = require("avante.utils")
 
@@ -258,6 +263,8 @@ function M.focus(opts)
   end
 end
 
+---Select a model
+---Saves the choice to stdpath("state")
 function M.select_model() require("avante.model_selector").open() end
 
 function M.select_acp_model() require("avante.acp_config_selector").open_model() end
@@ -327,6 +334,7 @@ end
 
 function M.stop() require("avante.llm").cancel_inflight_request() end
 
+---@export M
 return setmetatable(M, {
   __index = function(t, k)
     local module = require("avante")

--- a/lua/avante/commands.lua
+++ b/lua/avante/commands.lua
@@ -69,7 +69,7 @@
 ---
 ---                                                     *:AvanteModels*
 --- :AvanteModels
----         Show the model list.
+---         Show the model list. See |avante-api.select_model|
 ---
 ---                                                     *:AvanteACPModels*
 --- :AvanteACPModels

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -1095,7 +1095,7 @@ M._defaults = {
 M._options = {}
 
 ---@diagnostic disable-next-line: param-type-mismatch
-local function get_config_dir_path() return vim.fs.joinpath(vim.fn.expand("~"), ".config", "avante.nvim") end
+local function get_config_dir_path() return vim.fs.joinpath(vim.fn.stdpath("state"), "avante") end
 local function get_config_file_path() return vim.fs.joinpath(get_config_dir_path(), "config.json") end
 
 --- Function to save the last used model

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -978,6 +978,7 @@ function Sidebar:handle_expand_message(message_uuid, expanded)
   end, 100)
 end
 
+---@private
 function Sidebar:edit_user_request()
   local block = self:get_current_user_request_block()
   if not block then return end
@@ -991,6 +992,7 @@ function Sidebar:edit_user_request()
 end
 
 ---@param current_cursor boolean
+---@private
 function Sidebar:apply(current_cursor)
   local response, response_start_line = self:get_content_between_separators()
   local all_snippets_map = extract_code_snippets_map(response)
@@ -1185,6 +1187,7 @@ function Sidebar:render_input(ask)
   )
 end
 
+---@private
 function Sidebar:render_selected_code()
   if not self.code.selection then return end
   if not Utils.is_valid_container(self.containers.selected_code) then return end
@@ -1205,6 +1208,7 @@ function Sidebar:render_selected_code()
   )
 end
 
+---@private
 function Sidebar:bind_apply_key()
   if self.containers.result then
     vim.keymap.set(
@@ -1216,12 +1220,14 @@ function Sidebar:bind_apply_key()
   end
 end
 
+---@private
 function Sidebar:unbind_apply_key()
   if self.containers.result then
     pcall(vim.keymap.del, "n", Config.mappings.sidebar.apply_cursor, { buffer = self.containers.result.bufnr })
   end
 end
 
+---@private
 function Sidebar:bind_retry_user_request_key()
   if self.containers.result then
     vim.keymap.set(
@@ -1233,6 +1239,7 @@ function Sidebar:bind_retry_user_request_key()
   end
 end
 
+---@private
 function Sidebar:unbind_retry_user_request_key()
   if self.containers.result then
     pcall(vim.keymap.del, "n", Config.mappings.sidebar.retry_user_request, { buffer = self.containers.result.bufnr })


### PR DESCRIPTION
that's actually the one module we want to advertise to the user !
Started hiding uninteresting functions that bloat the doc for no good reason.

:AvanteModels would save the selected model in hardcoded ~/.config/avante.nvim/config.json.

It now lives in stdpath("state")/avante/config.json, ie, ~/.local/state/nvim/avante/config.json on linux