### PR TITLE
fix(build): fetch remote tags in Build.ps1 to support shallow clones

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -104,7 +104,53 @@ function Main {
         Write-Host "Building for $Version..."
         Build-FromSource $Version
     } else {
-        $latestTag = git describe --tags --abbrev=0 2>&1 | Where-Object { $_ -ne $null }
+        function Test-GitTagLocal($tag) {
+            try {
+                $null = git rev-parse $tag 2>$null
+                return $true
+            } catch {
+                return $false
+            }
+        }
+
+        function Sync-GitTag($remoteUrl, $tagRef) {
+            try {
+                git fetch $remoteUrl "$tagRef`:$tagRef" 2>$null
+            } catch {
+                # Ignore individual fetch failures
+            }
+        }
+
+        function Fetch-RemoteTags {
+            try {
+                $tags = git ls-remote --tags $remoteUrl 2>$null | Select-String "refs/tags/v"
+                if ($null -eq $tags) { return }
+
+                foreach ($line in $tags) {
+                    $parts = ($line.ToString() -split "\s+")
+                    if ($parts.Length -lt 2) { continue }
+
+                    $tagRef = $parts[1]
+                    $tag = $tagRef -replace "^refs/tags/", ""
+
+                    if (-not (Test-GitTagLocal $tag)) {
+                        Sync-GitTag $remoteUrl $tagRef
+                    }
+                }
+            } catch {
+                # Ignore tag fetching errors
+            }
+        }
+
+        Fetch-RemoteTags
+
+        $latestTag = $null
+        try {
+            $latestTag = git describe --tags --abbrev=0 --match "v*" 2>$null
+        } catch {
+            $latestTag = $null
+        }
+
         $builtTag = if (Test-Path "lua/.tag") {
             Get-Content "lua/.tag"
         } else {

--- a/Build.ps1
+++ b/Build.ps1
@@ -146,7 +146,7 @@ function Main {
 
         $latestTag = $null
         try {
-            $latestTag = git describe --tags --abbrev=0 --match "v*" 2>$null
+            $latestTag = git tag --sort=-version:refname | Where-Object { $_ -like "v*" } | Select-Object -First 1
         } catch {
             $latestTag = $null
         }


### PR DESCRIPTION
# Description

Fixes #3202.

Package managers like `lazy.nvim` typically use shallow clones that omit git tags. Previously, running `git describe` in `Build.ps1` without local tags would fail. Due to PowerShell's `$ErrorActionPreference = 'Stop'` and stderr redirection, this failure would cause an immediate crash of the script, preventing the download of prebuilt binaries on Windows.

This PR aligns `Build.ps1` with the existing behavior of `build.sh` by:

- Adding a `Fetch-RemoteTags` function to silently fetch required tags from the remote origin before attempting to resolve the version.
- Wrapping the `git describe` call in a `try/catch` block to safely handle any potential Git errors without terminating the entire build process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Verified locally on Windows (PowerShell) using a shallow clone (simulating a standard `lazy.nvim` installation).
- [x] Confirmed that `Build.ps1` successfully fetches tags from the remote and completes the execution without crashing.