### PR TITLE
fix(openai): make reasoning work for both mistral and deepseek

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -323,6 +323,10 @@ function M:parse_messages(opts)
                 }
 
                 tool_call_message.reasoning_content = pending_reasoning_content
+                if tool_call_message.reasoning_content == nil and not self.is_mistral(provider_conf.endpoint) then
+                  -- Strict-schema OpenAI-compatible servers (e.g. some Mistral deployments) reject unknown fields entirely
+                  tool_call_message.reasoning_content = ""
+                end
                 pending_reasoning_content = nil
 
                 table.insert(messages, tool_call_message)


### PR DESCRIPTION
https://github.com/avante-corp/avante.nvim/pull/3187 fixed an issue for mistral but doing so broke the openai provider for deekseek. This should fix it for both. Maybe we should introduce a M.is_strict but not worth the effort for now.

Should fix https://github.com/avante-corp/avante.nvim/issues/3203