### PR TITLE
fix(acp): never send an empty prompt array for the edit flow

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1576,6 +1576,25 @@ function M._continue_stream_acp(opts, acp_client, session_id)
           .. user_messages_added
           .. " recent user messages</system_context>",
       })
+    elseif #prompt == 0 then
+      -- Session continuation without any history user messages (e.g. the edit
+      -- flow, which submits only `instructions`): fall back to the freshly
+      -- generated prompts, same as the branch below. Without this, an empty
+      -- prompt array is sent, which ACP agents reject (opencode/GLM: "The
+      -- messages parameter is illegal").
+      local prompt_opts = M.generate_prompts(opts)
+      table.insert(prompt, {
+        type = "text",
+        text = prompt_opts.system_prompt,
+      })
+      for _, message in ipairs(prompt_opts.messages) do
+        if message.role == "user" then
+          table.insert(prompt, {
+            type = "text",
+            text = message.content,
+          })
+        end
+      end
     end
   else
     if donot_use_builtin_system_prompt then


### PR DESCRIPTION
The edit flow (Selection:submit_input, i.e. <leader>ae / :AvanteEdit) calls Llm.stream with only `instructions`, `selected_code` and `selected_files` -- no `history_messages`. In _stream_acp, prompt assembly for an existing ACP session takes the `elseif opts.acp_session_id` branch, which builds the prompt exclusively from user messages found in the (here: empty) history. Nothing is inserted, so avante sends `prompt: []` via session/prompt.

ACP agents turn that into an empty user message, which the model provider rejects. With opencode -> GLM (zai-coding-plan) every edit request fails immediately with:

    Error occurred while processing the response: {
      code = -32603,
      data = { errorName = "APIError", service = "session" },
      message = "Internal error: The messages parameter is illegal.
                 Please check the documentation."
    }

The ask flow is unaffected because the typed request is added to the history before streaming, so the session-continuation branch always finds at least one user message. The same is true for the session-recovery branch, which is why this only bites the standalone PromptInput edit flow.

Fix: when the session-continuation branch produced zero prompt blocks, fall back to M.generate_prompts(opts) -- the same code the no-session branch already uses -- so the instruction and selected-code context are always sent.

Verified against `opencode acp` with GLM: the edit flow now sends 4 prompt blocks instead of 0 and the turn completes with reason="complete".