### PR TITLE
feat!: select models for current provider only

### DIFF
--- a/doc/avante.txt
+++ b/doc/avante.txt
@@ -638,9 +638,11 @@ M.focus({opts?})                                              *avante-api.focus*
         {opts?}  (AskOptions)
 
 
-M.select_model()                                       *avante-api.select_model*
-    Select a model
-    Saves the choice to stdpath("state")
+M.select_model({all?})                                 *avante-api.select_model*
+    Select a model from current provider (default) or all providers
+
+    Parameters: ~
+        {all?}  (boolean)  Saves the choice to stdpath("state")
 
 
 M.select_acp_model()                               *avante-api.select_acp_model*

--- a/doc/avante.txt
+++ b/doc/avante.txt
@@ -736,8 +736,9 @@ Commands (:AvanteAsk,...)                                      *avante-commands*
          Toggle the Avante sidebar.
 
                                                      *:AvanteModels*
- :AvanteModels
-         Show the model list. See |avante-api.select_model|
+ :AvanteModels [--all] [timeout]
+         Show the model list, optionally querying all providers and overriding
+         the model-list timeout in milliseconds. See |avante-api.select_model|
 
                                                      *:AvanteACPModels*
  :AvanteACPModels
@@ -3657,7 +3658,10 @@ M.on_error({result})                          *avante-providers-ollama.on_error*
         {result}  (table)
 
 
-M:list_models()                            *avante-providers-ollama:list_models*
+M:list_models({timeout?})                  *avante-providers-ollama:list_models*
+
+    Parameters: ~
+        {timeout?}  (integer)  Timeout in milliseconds
 
 
 M.check_endpoint_alive()          *avante-providers-ollama.check_endpoint_alive*
@@ -3695,8 +3699,11 @@ M.is_mistral()                              *avante-providers-openai.is_mistral*
         (boolean)
 
 
-M:list_models()                            *avante-providers-openai:list_models*
+M:list_models({timeout?})                  *avante-providers-openai:list_models*
     Asking remote provider to list available models
+
+    Parameters: ~
+        {timeout?}  (integer)  Timeout in milliseconds, overriding the provider configuration
 
     Returns: ~
         (AvanteProviderModelList)

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -256,9 +256,10 @@ function M.focus(opts)
   end
 end
 
----Select a model
+---Select a model from current provider (default) or all providers
+---@param all? boolean
 ---Saves the choice to stdpath("state")
-function M.select_model() require("avante.model_selector").open() end
+function M.select_model(all) require("avante.model_selector").open(all) end
 
 function M.select_acp_model() require("avante.acp_config_selector").open_model() end
 

--- a/lua/avante/commands.lua
+++ b/lua/avante/commands.lua
@@ -68,8 +68,9 @@
 ---         Toggle the Avante sidebar.
 ---
 ---                                                     *:AvanteModels*
---- :AvanteModels
----         Show the model list. See |avante-api.select_model|
+--- :AvanteModels [--all] [timeout]
+---         Show the model list, optionally querying all providers and overriding
+---         the model-list timeout in milliseconds. See |avante-api.select_model|
 ---
 ---                                                     *:AvanteACPModels*
 --- :AvanteACPModels

--- a/lua/avante/model_selector.lua
+++ b/lua/avante/model_selector.lua
@@ -80,7 +80,9 @@ local function create_model_entries(provider_name, provider_cfg)
   return res
 end
 
-function M.open()
+---Open a modal to select a specific model
+---@param all? boolean loop over all providers if true
+function M.open(all)
   M.list_models_invoked = {}
   M.list_models_returned = {}
   local models = {}
@@ -88,8 +90,10 @@ function M.open()
   Utils.info("listing models")
 
   -- Collect models from providers
-  for provider_name, _ in pairs(Config.providers) do
+  local provider_names = all and vim.tbl_keys(Config.providers) or { Config.provider }
+  for _, provider_name in ipairs(provider_names) do
     local provider_cfg = Providers[provider_name]
+    if not provider_cfg then goto continue end
     if provider_cfg.hide_in_model_selector then goto continue end
     if not provider_cfg.is_env_set() then goto continue end
     local entries = create_model_entries(provider_name, provider_cfg)
@@ -155,7 +159,7 @@ function M.open()
   end
 
   local selector = Selector:new({
-    title = "Select Avante Model",
+    title = "Select Avante Model: ",
     items = items,
     default_item_id = default_item and default_item.name or nil,
     provider = Config.selector.provider,

--- a/lua/avante/model_selector.lua
+++ b/lua/avante/model_selector.lua
@@ -15,8 +15,9 @@ local list_models_cached_result = {}
 --- Calls provider's list_models and caches result
 ---@param provider_name string
 ---@param provider_cfg table
+---@param timeout? integer Timeout in milliseconds
 ---@return table
-local function create_model_entries(provider_name, provider_cfg)
+local function create_model_entries(provider_name, provider_cfg, timeout)
   local res = {}
   if provider_cfg.list_models then
     local models
@@ -28,7 +29,7 @@ local function create_model_entries(provider_name, provider_cfg)
       if cached_result then
         models = cached_result
       else
-        models = provider_cfg:list_models()
+        models = provider_cfg:list_models(timeout)
         list_models_cached_result[cache_key] = models
       end
     else
@@ -81,8 +82,9 @@ local function create_model_entries(provider_name, provider_cfg)
 end
 
 ---Open a modal to select a specific model
----@param all? boolean loop over all providers if true
-function M.open(all)
+---@param all? boolean Loop over all providers if true
+---@param timeout? integer Timeout in milliseconds for listing models
+function M.open(all, timeout)
   M.list_models_invoked = {}
   M.list_models_returned = {}
   local models = {}
@@ -96,7 +98,7 @@ function M.open(all)
     if not provider_cfg then goto continue end
     if provider_cfg.hide_in_model_selector then goto continue end
     if not provider_cfg.is_env_set() then goto continue end
-    local entries = create_model_entries(provider_name, provider_cfg)
+    local entries = create_model_entries(provider_name, provider_cfg, timeout)
     models = vim.list_extend(models, entries)
     ::continue::
   end

--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -251,7 +251,8 @@ function M:is_disable_stream() return false end
 
 setmetatable(M, { __index = OpenAI })
 
-function M:list_models()
+---@param timeout? integer Timeout in milliseconds, overriding the provider configuration
+function M:list_models(timeout)
   if M._model_list_cache then return M._model_list_cache end
   if not M._is_setup then M.setup() end
   -- refresh token synchronously, only if it has expired
@@ -261,7 +262,7 @@ function M:list_models()
   local headers = self:build_headers()
   local curl_opts = {
     headers = Utils.tbl_override(headers, self.extra_headers),
-    timeout = provider_conf.timeout,
+    timeout = timeout or provider_conf.timeout,
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
   }

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -349,11 +349,12 @@ local function query_models(opts, timeout)
 end
 
 -- List available models using Ollama's tags API
-function M:list_models()
+---@param timeout? integer Timeout in milliseconds
+function M:list_models(timeout)
   -- Return cached models if available
   if self._model_list_cache then return self._model_list_cache end
 
-  local result, error = query_models(self)
+  local result, error = query_models(self, timeout)
   if not result then
     assert(error)
     Utils.error(error)

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -51,8 +51,9 @@ function M.is_openrouter(url) return url:match("^https://openrouter%.ai/") end
 function M.is_mistral(url) return url:match("^https://api%.mistral%.ai/") end
 
 ---Asking remote provider to list available models
+---@param timeout? integer Timeout in milliseconds, overriding the provider configuration
 ---@return AvanteProviderModelList
-function M:list_models()
+function M:list_models(timeout)
   Utils.info("Asking remote for available models")
   if self == nil or self == M then
     local ok, provider = pcall(function() return Providers[Config.provider] end)
@@ -86,7 +87,7 @@ function M:list_models()
     headers = Utils.tbl_override(headers, self.extra_headers),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    timeout = provider_conf.timeout,
+    timeout = timeout or provider_conf.timeout,
   })
 
   if response.status ~= 200 then

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -367,7 +367,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field on_error? fun(result: table<string, any>): nil
 ---@field transform_tool? fun(self: AvanteProviderFunctor, tool: AvanteLLMTool, use_prefix?: boolean): AvanteOpenAITool | AvanteClaudeTool
 ---@field get_rate_limit_sleep_time? fun(self: AvanteProviderFunctor, headers: table<string, string>): integer | nil
----@field list_models? fun(self): AvanteProviderModelList | nil
+---@field list_models? fun(self, timeout?: integer): AvanteProviderModelList | nil
 ---
 ---@alias AvanteBedrockPayloadBuilder fun(self: AvanteBedrockModelHandler | AvanteBedrockProviderFunctor, prompt_opts: AvantePromptOptions, request_body: table<string, any>): table<string, any>
 ---

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -196,10 +196,15 @@ api.nvim_create_user_command("AvanteShowRepoMap", function() require("avante.rep
   desc = "avante: show repo map",
   nargs = 0,
 })
-api.nvim_create_user_command("AvanteModels", function() require("avante.model_selector").open() end, {
-  desc = "avante: show models",
-  nargs = 0,
-})
+api.nvim_create_user_command(
+  "AvanteModels",
+  function(opts) require("avante.model_selector").open(opts.args == "--all") end,
+  {
+    desc = "avante: show models",
+    nargs = "?",
+    complete = function() return { "--all" } end,
+  }
+)
 api.nvim_create_user_command("AvanteACPModels", function() require("avante.api").select_acp_model() end, {
   desc = "avante: switch ACP model",
   nargs = 0,

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -196,15 +196,27 @@ api.nvim_create_user_command("AvanteShowRepoMap", function() require("avante.rep
   desc = "avante: show repo map",
   nargs = 0,
 })
-api.nvim_create_user_command(
-  "AvanteModels",
-  function(opts) require("avante.model_selector").open(opts.args == "--all") end,
-  {
-    desc = "avante: show models",
-    nargs = "?",
-    complete = function() return { "--all" } end,
-  }
-)
+api.nvim_create_user_command("AvanteModels", function(opts)
+  local all = false
+  local timeout
+  for _, arg in ipairs(opts.fargs) do
+    if arg == "--all" and not all then
+      all = true
+    else
+      local value = tonumber(arg)
+      if timeout ~= nil or not value or value <= 0 or value % 1 ~= 0 then
+        Utils.error("Invalid arguments. Usage: AvanteModels [--all] [timeout]")
+        return
+      end
+      timeout = value
+    end
+  end
+  require("avante.model_selector").open(all, timeout)
+end, {
+  desc = "avante: show models",
+  nargs = "*",
+  complete = function() return { "--all" } end,
+})
 api.nvim_create_user_command("AvanteACPModels", function() require("avante.api").select_acp_model() end, {
   desc = "avante: switch ACP model",
   nargs = 0,


### PR DESCRIPTION
AvanteModels lists models across all providers by default. Same for
/model . This causes problems if one of the provider fails to answer
since we have long timeouts by default.
Ideally we would ask all the providers in parallel, possibly with a
shorter timeout than for generating requests.
Old behavior can still be restored by appending `
--all` to command eg:
`
:AvanteModels --all`