### PR TITLE
fix: fix openai responses api calling, support_previous_response_id flag

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -900,7 +900,7 @@ function M:parse_curl_args(prompt_opts)
       end
     end
 
-    if has_function_outputs and self.last_response_id then
+    if has_function_outputs and self.last_response_id and provider_conf.support_previous_response_id then
       -- When sending function outputs, use previous_response_id
       base_body.previous_response_id = self.last_response_id
       -- Only send the function outputs, not the full history


### PR DESCRIPTION
When `use_response_api = true`,  set `support_previous_response_id = true` or `support_previous_response_id = false`,
the following error will occur:
```
Error: {
~        │  message = "previous_response_id requires an OpenAI API-key
~        │  account for HTTP requests",
~        │  type = "invalid_request_error"
~        │}
```

When  `support_previous_response_id = false`, should execute https://github.com/avante-corp/avante.nvim/blob/main/lua/avante/providers/openai.lua#L914-L917

So following config is working:
```lua
openai = {
          __inherited_from = 'openai',
          api_key_name = 'AVANTE_OPENAI_API_KEY',
          endpoint = 'https://tk.air-class.com:8080/v1',
          model = 'gpt-5.6-sol',
          use_response_api = true,
          support_previous_response_id = false,
          extra_request_body = {
            reasoning_effort = 'high',
            stream = true,
          },
},
```

But `support_previous_response_id = true` is still not working, maybe there are other reasons.
