### PR TITLE
fix: Fix not closed file handle in view.lua

### DIFF
--- a/lua/avante/llm_tools/view.lua
+++ b/lua/avante/llm_tools/view.lua
@@ -93,11 +93,9 @@ function M.func(input, opts)
   if not input.path then return false, "path is required" end
   if on_log then on_log("path: " .. input.path) end
   local abs_path = Helpers.get_abs_path(input.path)
-  if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return false, "Path not found: " .. abs_path end
+  if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if vim.fn.isdirectory(abs_path) == 1 then return false, "Path is a directory: " .. abs_path end
-  local file = io.open(abs_path, "r")
-  if not file then return false, "file not found: " .. abs_path end
   local lines = Utils.read_file_from_buf_or_disk(abs_path)
   local start_line = input.start_line
   local end_line = input.end_line


### PR DESCRIPTION
No need to open a file to determine whether it exists.
And the file was not closed at the end, resulting in a file handle resource leak.
Also, move the `exists` check to before the `has_permission_to_access` check.